### PR TITLE
Added Discord link to community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Links from language x to rust
 * [stackoverflow](http://stackoverflow.com/questions/tagged/rust) questions... answered
 * [Rust nyc](https://www.meetup.com/rust-nyc/) IRL rustaceans, right in your back yard!
 * [Rust Discord Server](https://discord.com/invite/rust-lang) Official Rust-lang discord server.
+
 ### conferences
 
 * [Rustconf](http://rustconf.com/)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Links from language x to rust
 * [/r/rust](https://www.reddit.com/r/rust) community feedback loops
 * [stackoverflow](http://stackoverflow.com/questions/tagged/rust) questions... answered
 * [Rust nyc](https://www.meetup.com/rust-nyc/) IRL rustaceans, right in your back yard!
-
+* [Rust Discord Server](https://discord.com/invite/rust-lang) Official Rust-lang discord server.
 ### conferences
 
 * [Rustconf](http://rustconf.com/)


### PR DESCRIPTION
I added official Rust-lang Discord server behind to "accessing the community"